### PR TITLE
Remove module name prefix from metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ This expectes a JSON log format with one line per HTTP request logged with the f
 
 The metrics collected are:
 
-* `http_request_count_total{ section_io_module_name="module name", hostname="www.example.com", status="200" }` - Counter of number of HTTP requests by hostname & status.
-* `http_bytes_total{ section_io_module_name="module name", hostname="www.example.com", status="200" }` - Counter of sum of bytes sent downstream by hostname & status.
-* `http_json_parse_errors_total{ section_io_module_name="module name" }` - Counter of the number of times it has been unable to JSON parse a log line.
+* `section_http_request_count_total{ section_io_module_name="module name", hostname="www.example.com", status="200" }` - Counter of number of HTTP requests by hostname & status.
+* `section_http_bytes_total{ section_io_module_name="module name", hostname="www.example.com", status="200" }` - Counter of sum of bytes sent downstream by hostname & status.
+* `section_http_json_parse_errors_total{ section_io_module_name="module name" }` - Counter of the number of times it has been unable to JSON parse a log line.
 
 The `section_io_module_name` is configured as a target label on the service monitor for the module using this module.
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ This expectes a JSON log format with one line per HTTP request logged with the f
 
 The metrics collected are:
 
-* `module_name_http_request_count_total{ hostname="www.example.com", status="200" }` - Counter of number of HTTP requests by hostname & status.
-* `module_name_http_bytes_total{ hostname="www.example.com", status="200" }` - Counter of sum of bytes sent downstream by hostname & status.
-* `module_name_http_json_parse_errors_total` - Counter of the number of times it has been unable to JSON parse a log line.
+* `http_request_count_total{ section_io_module_name="module name", hostname="www.example.com", status="200" }` - Counter of number of HTTP requests by hostname & status.
+* `http_bytes_total{ section_io_module_name="module name", hostname="www.example.com", status="200" }` - Counter of sum of bytes sent downstream by hostname & status.
+* `http_json_parse_errors_total{ section_io_module_name="module name" }` - Counter of the number of times it has been unable to JSON parse a log line.
 
-The `module_name` portion of the metric name is constructed from the `SECTION_PROXY_NAME` environment variable.
+The `section_io_module_name` is configured as a target label on the service monitor for the module using this module.
 
 The metrics are published as a Prometheus exporter by default on port `9000` with the path `/metrics`.

--- a/metrics.go
+++ b/metrics.go
@@ -110,7 +110,7 @@ func StartReader(file io.Reader, output io.Writer, errorWriter io.Writer) {
 
 // SetupModule does the default setup scenario: creating & opening the FIFO file,
 // starting the Prometheus server and starting the reader.
-func SetupModule(moduleName string, path string, stdout io.Writer, stderr io.Writer) error {
+func SetupModule(path string, stdout io.Writer, stderr io.Writer) error {
 	err := CreateLogFifo(path)
 	if err != nil {
 		return err
@@ -121,7 +121,7 @@ func SetupModule(moduleName string, path string, stdout io.Writer, stderr io.Wri
 		return err
 	}
 
-	InitMetrics(moduleName)
+	InitMetrics()
 
 	StartReader(reader, stdout, stderr)
 

--- a/p8s.go
+++ b/p8s.go
@@ -37,25 +37,22 @@ func addRequest(hostname string, status string, bytes int) {
 
 // InitMetrics sets up the prometheus registry and creates the metrics. Calling this
 // will reset any collected metrics
-func InitMetrics(promeNamespace string) {
+func InitMetrics() {
 	registry = prometheus.NewRegistry()
 
 	requestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: promeNamespace,
 		Subsystem: promeSubsystem,
 		Name:      "request_count_total",
 		Help:      "Total count of HTTP requests.",
 	}, p8sLabels)
 
 	bytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: promeNamespace,
 		Subsystem: promeSubsystem,
 		Name:      "bytes_total",
 		Help:      "Total sum of response bytes.",
 	}, p8sLabels)
 
 	jsonParseErrorTotal = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: promeNamespace,
 		Subsystem: promeSubsystem,
 		Name:      "json_parse_errors_total",
 		Help:      "Total count of JSON parsing errors.",

--- a/p8s.go
+++ b/p8s.go
@@ -38,21 +38,25 @@ func addRequest(hostname string, status string, bytes int) {
 // InitMetrics sets up the prometheus registry and creates the metrics. Calling this
 // will reset any collected metrics
 func InitMetrics() {
+	const promeNamespace = "section"
 	registry = prometheus.NewRegistry()
 
 	requestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promeNamespace,
 		Subsystem: promeSubsystem,
 		Name:      "request_count_total",
 		Help:      "Total count of HTTP requests.",
 	}, p8sLabels)
 
 	bytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: promeNamespace,
 		Subsystem: promeSubsystem,
 		Name:      "bytes_total",
 		Help:      "Total sum of response bytes.",
 	}, p8sLabels)
 
 	jsonParseErrorTotal = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: promeNamespace,
 		Subsystem: promeSubsystem,
 		Name:      "json_parse_errors_total",
 		Help:      "Total count of JSON parsing errors.",

--- a/p8s_test.go
+++ b/p8s_test.go
@@ -91,12 +91,12 @@ func testCountersIncrease(t *testing.T, stdout *bytes.Buffer) {
 
 	actual := gatherP8sResponse(t)
 
-	expected := `http_request_count_total{hostname="bar.example.com",status="304"} 1`
+	expected := `section_http_request_count_total{hostname="bar.example.com",status="304"} 1`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
 
-	expected = `http_bytes_total{hostname="www.example.com",status="304"} 1790`
+	expected = `section_http_bytes_total{hostname="www.example.com",status="304"} 1790`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
@@ -115,12 +115,12 @@ func testBytesAndBytesSentAreRead(t *testing.T, stdout *bytes.Buffer) {
 
 	actual := gatherP8sResponse(t)
 
-	expected := `http_request_count_total{hostname="www.example.com",status="200"} 2`
+	expected := `section_http_request_count_total{hostname="www.example.com",status="200"} 2`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
 
-	expected = `http_bytes_total{hostname="www.example.com",status="200"} 30`
+	expected = `section_http_bytes_total{hostname="www.example.com",status="200"} 30`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
@@ -141,12 +141,12 @@ func testInvalidBytesAndBytesSent(t *testing.T, stdout *bytes.Buffer) {
 
 	actual := gatherP8sResponse(t)
 
-	expected := `http_request_count_total{hostname="www.example.com",status="200"} 4`
+	expected := `section_http_request_count_total{hostname="www.example.com",status="200"} 4`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
 
-	expected = `http_bytes_total{hostname="www.example.com",status="200"} 30`
+	expected = `section_http_bytes_total{hostname="www.example.com",status="200"} 30`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
@@ -166,7 +166,7 @@ func testJSONParseErrors(t *testing.T, stdout *bytes.Buffer) {
 
 	actual := gatherP8sResponse(t)
 
-	expected := `http_json_parse_errors_total 3`
+	expected := `section_http_json_parse_errors_total 3`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
@@ -195,12 +195,12 @@ func testP8sServer(t *testing.T, stdout *bytes.Buffer) {
 
 	body := getP8sHTTPResponse(t)
 
-	expected := `http_request_count_total{hostname="bar.example.com",status="304"} 1`
+	expected := `section_http_request_count_total{hostname="bar.example.com",status="304"} 1`
 	if !strings.Contains(body, expected) {
 		t.Errorf("HTTP response:\n%s\n does not contain expected %s", body, expected)
 	}
 
-	expected = `http_bytes_total{hostname="www.example.com",status="304"} 1790`
+	expected = `section_http_bytes_total{hostname="www.example.com",status="304"} 1790`
 	if !strings.Contains(body, expected) {
 		t.Errorf("HTTP response:\n%s\n does not contain expected %s", body, expected)
 	}

--- a/p8s_test.go
+++ b/p8s_test.go
@@ -11,10 +11,6 @@ import (
 	"github.com/prometheus/common/expfmt"
 )
 
-const (
-	moduleName = "test_module"
-)
-
 func getP8sHTTPResponse(t *testing.T) string {
 	resp, err := http.Get(MetricsURI)
 	if err != nil {
@@ -61,7 +57,7 @@ func testLogsOutputEqualsInput(t *testing.T, stdout *bytes.Buffer) {
 		`{"time":"2019-06-20T01:34:36+00:00","request_time":"0.075","request":"GET /a/path HTTP/1.1","http_accept_encoding":"gzip","http_x_forwarded_proto":"https","http_upgrade":"-","http_connection":"-","status":"200","bytes_sent":"2126","body_bytes_sent":"1665","upstream_label":"default","upstream_addr":"198.51.100.1:443","upstream_status":"200","upstream_request_connection":"","upstream_request_host":"in.example.com","upstream_header_time":"0.075","upstream_connect_time":"0.056","upstream_response_time":"0.075","upstream_response_length":"1665","upstream_bytes_received":"2056","upstream_http_content_type":"application/javascript","upstream_http_cache_control":"max-age=60","upstream_http_content_length":"-","upstream_http_content_encoding":"gzip","upstream_http_transfer_encoding":"chunked","sent_http_content_length":"-","sent_http_content_encoding":"gzip","sent_http_transfer_encoding":"chunked","section-io-id":"789addb393a18ff1caf5d776b53cf30e"}`,
 	}
 
-	InitMetrics(moduleName)
+	InitMetrics()
 
 	writeLogs(t, logs)
 
@@ -89,18 +85,18 @@ func testCountersIncrease(t *testing.T, stdout *bytes.Buffer) {
 		`{"time":"2019-06-20T01:34:36+00:00","request_time":"0.075","hostname":"www.example.com","request":"GET /a/path HTTP/1.1","http_accept_encoding":"gzip","http_x_forwarded_proto":"https","http_upgrade":"-","http_connection":"-","status":"200","bytes_sent":"2126","body_bytes_sent":"1665","upstream_label":"default","upstream_addr":"198.51.100.1:443","upstream_status":"200","upstream_request_connection":"","upstream_request_host":"in.example.com","upstream_header_time":"0.075","upstream_connect_time":"0.056","upstream_response_time":"0.075","upstream_response_length":"1665","upstream_bytes_received":"2056","upstream_http_content_type":"application/javascript","upstream_http_cache_control":"max-age=60","upstream_http_content_length":"-","upstream_http_content_encoding":"gzip","upstream_http_transfer_encoding":"chunked","sent_http_content_length":"-","sent_http_content_encoding":"gzip","sent_http_transfer_encoding":"chunked","section-io-id":"789addb393a18ff1caf5d776b53cf30e"}`,
 	}
 
-	InitMetrics(moduleName)
+	InitMetrics()
 
 	writeLogs(t, logs)
 
 	actual := gatherP8sResponse(t)
 
-	expected := `test_module_http_request_count_total{hostname="bar.example.com",status="304"} 1`
+	expected := `http_request_count_total{hostname="bar.example.com",status="304"} 1`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
 
-	expected = `test_module_http_bytes_total{hostname="www.example.com",status="304"} 1790`
+	expected = `http_bytes_total{hostname="www.example.com",status="304"} 1790`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
@@ -113,18 +109,18 @@ func testBytesAndBytesSentAreRead(t *testing.T, stdout *bytes.Buffer) {
 		`{"time":"2019-06-20T01:34:36+00:00","request_time":"0.069","hostname":"www.example.com","status":"200","bytes_sent":"20","request":"GET /a/path HTTP/1.1","http_accept_encoding":"gzip","http_x_forwarded_proto":"https","http_upgrade":"-","http_connection":"-","body_bytes_sent":"0","upstream_label":"default","upstream_addr":"198.51.100.1:443","upstream_status":"304","upstream_request_connection":"","upstream_request_host":"in.example.com","upstream_header_time":"0.069","upstream_connect_time":"0.052","upstream_response_time":"0.069","upstream_response_length":"0","upstream_bytes_received":"288","upstream_http_content_type":"-","upstream_http_cache_control":"max-age=60","upstream_http_content_length":"-","upstream_http_content_encoding":"-","upstream_http_transfer_encoding":"-","sent_http_content_length":"-","sent_http_content_encoding":"-","sent_http_transfer_encoding":"-","section-io-id":"451e230222237f722eb49324d47142f6"}`,
 	}
 
-	InitMetrics(moduleName)
+	InitMetrics()
 
 	writeLogs(t, logs)
 
 	actual := gatherP8sResponse(t)
 
-	expected := `test_module_http_request_count_total{hostname="www.example.com",status="200"} 2`
+	expected := `http_request_count_total{hostname="www.example.com",status="200"} 2`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
 
-	expected = `test_module_http_bytes_total{hostname="www.example.com",status="200"} 30`
+	expected = `http_bytes_total{hostname="www.example.com",status="200"} 30`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
@@ -139,18 +135,18 @@ func testInvalidBytesAndBytesSent(t *testing.T, stdout *bytes.Buffer) {
 		`{"time":"2019-06-20T01:34:36+00:00","request_time":"0.069","hostname":"www.example.com","status":"200","bytes_sent":"-","request":"GET /a/path HTTP/1.1","http_accept_encoding":"gzip","http_x_forwarded_proto":"https","http_upgrade":"-","http_connection":"-","body_bytes_sent":"0","upstream_label":"default","upstream_addr":"198.51.100.1:443","upstream_status":"304","upstream_request_connection":"","upstream_request_host":"in.example.com","upstream_header_time":"0.069","upstream_connect_time":"0.052","upstream_response_time":"0.069","upstream_response_length":"0","upstream_bytes_received":"288","upstream_http_content_type":"-","upstream_http_cache_control":"max-age=60","upstream_http_content_length":"-","upstream_http_content_encoding":"-","upstream_http_transfer_encoding":"-","sent_http_content_length":"-","sent_http_content_encoding":"-","sent_http_transfer_encoding":"-","section-io-id":"451e230222237f722eb49324d47142f6"}`,
 	}
 
-	InitMetrics(moduleName)
+	InitMetrics()
 
 	writeLogs(t, logs)
 
 	actual := gatherP8sResponse(t)
 
-	expected := `test_module_http_request_count_total{hostname="www.example.com",status="200"} 4`
+	expected := `http_request_count_total{hostname="www.example.com",status="200"} 4`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
 
-	expected = `test_module_http_bytes_total{hostname="www.example.com",status="200"} 30`
+	expected = `http_bytes_total{hostname="www.example.com",status="200"} 30`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
@@ -164,13 +160,13 @@ func testJSONParseErrors(t *testing.T, stdout *bytes.Buffer) {
 		`{"Broken: "Property"}`,
 	}
 
-	InitMetrics(moduleName)
+	InitMetrics()
 
 	writeLogs(t, logs)
 
 	actual := gatherP8sResponse(t)
 
-	expected := `test_module_http_json_parse_errors_total 3`
+	expected := `http_json_parse_errors_total 3`
 	if !strings.Contains(actual, expected) {
 		t.Errorf("Output:\n%s\n does not contain expected %s", actual, expected)
 	}
@@ -191,7 +187,7 @@ func testP8sServer(t *testing.T, stdout *bytes.Buffer) {
 		`{"time":"2019-06-20T01:34:36+00:00","request_time":"0.075","hostname":"www.example.com","request":"GET /a/path HTTP/1.1","http_accept_encoding":"gzip","http_x_forwarded_proto":"https","http_upgrade":"-","http_connection":"-","status":"200","bytes_sent":"2126","body_bytes_sent":"1665","upstream_label":"default","upstream_addr":"198.51.100.1:443","upstream_status":"200","upstream_request_connection":"","upstream_request_host":"in.example.com","upstream_header_time":"0.075","upstream_connect_time":"0.056","upstream_response_time":"0.075","upstream_response_length":"1665","upstream_bytes_received":"2056","upstream_http_content_type":"application/javascript","upstream_http_cache_control":"max-age=60","upstream_http_content_length":"-","upstream_http_content_encoding":"gzip","upstream_http_transfer_encoding":"chunked","sent_http_content_length":"-","sent_http_content_encoding":"gzip","sent_http_transfer_encoding":"chunked","section-io-id":"789addb393a18ff1caf5d776b53cf30e"}`,
 	}
 
-	InitMetrics(moduleName)
+	InitMetrics()
 
 	StartPrometheusServer(os.Stderr)
 
@@ -199,12 +195,12 @@ func testP8sServer(t *testing.T, stdout *bytes.Buffer) {
 
 	body := getP8sHTTPResponse(t)
 
-	expected := `test_module_http_request_count_total{hostname="bar.example.com",status="304"} 1`
+	expected := `http_request_count_total{hostname="bar.example.com",status="304"} 1`
 	if !strings.Contains(body, expected) {
 		t.Errorf("HTTP response:\n%s\n does not contain expected %s", body, expected)
 	}
 
-	expected = `test_module_http_bytes_total{hostname="www.example.com",status="304"} 1790`
+	expected = `http_bytes_total{hostname="www.example.com",status="304"} 1790`
 	if !strings.Contains(body, expected) {
 		t.Errorf("HTTP response:\n%s\n does not contain expected %s", body, expected)
 	}
@@ -226,7 +222,7 @@ func TestSetupModule(t *testing.T) {
 	}
 
 	var stdout bytes.Buffer
-	err := SetupModule(moduleName, fifoFilePath, &stdout, os.Stderr)
+	err := SetupModule(fifoFilePath, &stdout, os.Stderr)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
The module name is available via a label on the metric as configured in
the service monitor target labels section.

https://section.tpondemand.com/entity/5602-add-proxy-name-to-service-and