### PR TITLE
Close file when the reader finds EOF

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This module will intercept logs by reading from a fifo file, parse them to colle
 
 ## Expected Log Format
 
-This expectes a JSON log format with one line per HTTP request logged with the following properties:
+This expects a JSON log format with one line per HTTP request logged with the following properties:
 
 * `hostname` - The value of the `Host` HTTP request header.
 * `status` - The value of the response status code.
@@ -28,7 +28,7 @@ The metrics are published as a Prometheus exporter by default on port `9000` wit
 
 ## Additional Labels
 
-Metrics can have additional labels added based on fields in the log lines. These can be added as a string array when setting up the module (see code below). The valus will pass through the `sanitizeValue` function in `metrics.go` so that fields that 
+Metrics can have additional labels added based on fields in the log lines. These can be added as a string array when setting up the module (see code below). The values will pass through the `sanitizeValue` function in `metrics.go` so that fields that 
 have known sanitization issues (like stripping the additional fields from `content_type`.) Additional sanitization can be added to this function as needed. The additional lables need to be valid Prometheus labels (see https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).  This is required, but not currently enforced by the code. The additional lables also need to match the name of a field in the log lines. Lines that do not have the field will create a metric with a blank label value.
 
 ## Usage

--- a/metrics.go
+++ b/metrics.go
@@ -138,7 +138,7 @@ func OpenReadFifo(path string) (io.ReadCloser, error) {
 // StartReader starts a loop in a goroutine that reads from the fifo file and writes out to the
 // output file. Any errors regarding parsing the log line are written to the errorWriter (eg os.Stderr)
 // but do not panic.
-func StartReader(file io.Reader, output io.Writer, errorWriter io.Writer) {
+func StartReader(file io.ReadCloser, output io.Writer, errorWriter io.Writer) {
 
 	go func() {
 
@@ -172,6 +172,10 @@ func StartReader(file io.Reader, output io.Writer, errorWriter io.Writer) {
 
 		// If EOF is reached the writer program closed the file, so reopen it
 		if err == io.EOF {
+			err := file.Close()
+			if err != nil {
+				panic(err)
+			}
 			file, err = OpenReadFifo(filepath)
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
The Reader leaves the file open if it finds an EOF. This causes multiple files to be opened until a process starts writing to the file resulting in elevated CPU and memory usage.