### PR TITLE
Handle the case if bytes_sent are negative

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -98,6 +98,11 @@ func getBytes(l map[string]interface{}) int {
 	// underlying type is. Atoi will return a 0 if the string can't be converted to an int.
 	bytes, _ = strconv.Atoi(fmt.Sprintf("%v", bytes))
 
+	// Do not fail if bytes_sent < 0, for e.g. 499 status code
+	if bytes.(int) < 0 {
+		bytes = 0
+	}
+
 	return bytes.(int)
 }
 

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -200,6 +200,13 @@ func TestGetBytesSent(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestNegativeBytesSent(t *testing.T) {
+	const expected = 0
+	actual := getBytes(map[string]interface{}{"bytes_sent": "-1"})
+
+	assert.Equal(t, expected, actual)
+}
+
 func TestGetBytesInt(t *testing.T) {
 	const expected = 5
 	actual := getBytes(map[string]interface{}{"bytes": 5})


### PR DESCRIPTION
Ran into an issue where the module was failing due to bytes_sent being negative : 

```
{"bytes_sent":"-1","content_type":"","status":"499","time":"2020-04-30T02:49:48Z","upstream_addr":"http://next-hop:80","upstream_response_length":"-1","upstream_status":"499"}
panic: counter cannot decrease in value

goroutine 10 [running]:
github.com/prometheus/client_golang/prometheus.(*counter).Add(0xc00007e100, 0xbff0000000000000)
	/go/pkg/mod/github.com/prometheus/client_golang@v1.0.0/prometheus/counter.go:89 +0x116
github.com/section-io/module-metrics.addRequest(0xc00039c360, 0xc00039c330)
	/go/pkg/mod/github.com/section-io/module-metrics@v0.3.4/p8s.go:50 +0xa8
github.com/section-io/module-metrics.StartReader.func1(0xc00001e1f0, 0x93a7a0, 0xc0000a6008, 0x93a7a0, 0xc0000a6010)
	/go/pkg/mod/github.com/section-io/module-metrics@v0.3.4/metrics.go:178 +0x3e0
created by github.com/section-io/module-metrics.StartReader
	/go/pkg/mod/github.com/section-io/module-metrics@v0.3.4/metrics.go:154 +0x95
```
