### PR TITLE
Collect all text/html responses as page views.

### DIFF
--- a/p8s.go
+++ b/p8s.go
@@ -40,7 +40,7 @@ var (
 
 func isPageView(logline map[string]interface{}) bool {
 	// Count text/html 2XX requests as page-views
-	return strings.HasPrefix(fmt.Sprintf("%v", logline["status"]), "2") && logline["content_type"] == "text/html"
+	return strings.HasPrefix(fmt.Sprintf("%v", logline["status"]), "2") && strings.HasPrefix(strings.ToLower(fmt.Sprintf("%v", logline["content_type"])), "text/html")
 }
 
 func addRequest(labels map[string]string, logline map[string]interface{}) {

--- a/p8s_test.go
+++ b/p8s_test.go
@@ -25,6 +25,9 @@ func TestIsPageView(t *testing.T) {
 
 	logline = map[string]interface{}{"content_type": "text/html", "status": "404"}
 	assert.False(t, isPageView(logline))
+
+	logline = map[string]interface{}{"content_type": "text/html;charset=UTF-8", "status": "200"}
+	assert.True(t, isPageView(logline))
 }
 
 func getP8sHTTPResponse(t *testing.T) string {


### PR DESCRIPTION
Allow for `content_types` with a charset suffix like `text/html;charset=UTF-8`