### PR TITLE
Limit the number of unique hostname labels

### DIFF
--- a/p8s.go
+++ b/p8s.go
@@ -7,7 +7,9 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -36,6 +38,12 @@ var (
 
 	// MetricsURI is the address the prometheus server is listening on
 	MetricsURI string
+
+	// vars related to limiting the number of unique hostname labels
+	uniqueHostnameMap       = make(map[string]time.Time)
+	maxUniqueHostnames      = 20000
+	hostnameCompactInterval = 1 * time.Minute
+	nextCompactTime         = time.Now().Add(hostnameCompactInterval)
 )
 
 func isPageView(logline map[string]interface{}) bool {
@@ -44,6 +52,22 @@ func isPageView(logline map[string]interface{}) bool {
 }
 
 func addRequest(labels map[string]string, logline map[string]interface{}) {
+	now := time.Now()
+	uniqueHostnameMap[labels["hostname"]] = now
+	if now.After(nextCompactTime) {
+		nextCompactTime = now.Add(hostnameCompactInterval)
+		cutoffTime := now.Add(-hostnameCompactInterval)
+		for k, v := range uniqueHostnameMap {
+			if v.Before(cutoffTime) {
+				delete(uniqueHostnameMap, k)
+			}
+		}
+	}
+	if len(uniqueHostnameMap) > maxUniqueHostnames {
+		// Use hard-coded hostname so wildcard domains don't make cardinality explode.
+		labels["hostname"] = "max-hostnames-reached"
+	}
+
 	bytes := getBytes(logline)
 
 	requestsTotal.With(labels).Inc()
@@ -98,6 +122,25 @@ func InitMetrics(additionalLabels ...string) *prometheus.Registry {
 	})
 
 	registry.MustRegister(requestsTotal, bytesTotal, pageViewTotal, jsonParseErrorTotal)
+
+	maxUniqueHostnamesStr := os.Getenv("MODULE_METRICS_MAX_HOSTNAMES")
+	if maxUniqueHostnamesStr != "" {
+		maxUniqueHostnamesInt, err := strconv.Atoi(maxUniqueHostnamesStr)
+		if err == nil {
+			maxUniqueHostnames = maxUniqueHostnamesInt
+			log.Printf("[DEBUG] Using %d for maxUniqueHostnames\n", maxUniqueHostnames)
+		}
+	}
+
+	hostnameCompactSecondsStr := os.Getenv("MODULE_METRICS_HOSTNAME_COMPACT_SECONDS")
+	if hostnameCompactSecondsStr != "" {
+		hostnameCompactSecondsInt, err := strconv.Atoi(maxUniqueHostnamesStr)
+		if err == nil {
+			hostnameCompactInterval = time.Second * time.Duration(hostnameCompactSecondsInt)
+			nextCompactTime = time.Now().Add(hostnameCompactInterval)
+			log.Printf("[DEBUG] Using %d seconds for hostnameCompactInterval\n", hostnameCompactSecondsInt)
+		}
+	}
 
 	go startPrometheusServer(os.Stderr)
 


### PR DESCRIPTION
When the (configurable) maximum number of unique hostnames have been
reached, the hostname used in the p8s labels will be replaced by
'max-hostnames-reached' to help keep cardinality under control. The map
used to keep track of unique hostnames is compacted every so often
(configurable).

Added 2 new environment variables:
- MODULE_METRICS_MAX_HOSTNAMES: The maximum number of unique hostnames
  to track. 20k by default.
- MODULE_METRICS_HOSTNAME_COMPACT_SECONDS: How often to check/compact
  the unique hostnames map. 60 seconds by default.