### PR TITLE
Remove broken hostname compaction

### DIFF
--- a/p8s.go
+++ b/p8s.go
@@ -40,7 +40,7 @@ var (
 
 	// vars related to limiting the number of unique hostname labels
 	uniqueHostnameMap  = make(map[string]struct{})
-	maxUniqueHostnames = 20000
+	maxUniqueHostnames = 1000
 )
 
 func isPageView(logline map[string]interface{}) bool {

--- a/p8s.go
+++ b/p8s.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -40,10 +39,8 @@ var (
 	MetricsURI string
 
 	// vars related to limiting the number of unique hostname labels
-	uniqueHostnameMap       = make(map[string]time.Time)
-	maxUniqueHostnames      = 20000
-	hostnameCompactInterval = 1 * time.Minute
-	nextCompactTime         = time.Now().Add(hostnameCompactInterval)
+	uniqueHostnameMap  = make(map[string]struct{})
+	maxUniqueHostnames = 20000
 )
 
 func isPageView(logline map[string]interface{}) bool {
@@ -52,20 +49,14 @@ func isPageView(logline map[string]interface{}) bool {
 }
 
 func addRequest(labels map[string]string, logline map[string]interface{}) {
-	now := time.Now()
-	uniqueHostnameMap[labels["hostname"]] = now
-	if now.After(nextCompactTime) {
-		nextCompactTime = now.Add(hostnameCompactInterval)
-		cutoffTime := now.Add(-hostnameCompactInterval)
-		for k, v := range uniqueHostnameMap {
-			if v.Before(cutoffTime) {
-				delete(uniqueHostnameMap, k)
-			}
+	_, ok := uniqueHostnameMap[labels["hostname"]]
+	if !ok {
+		if len(uniqueHostnameMap) < maxUniqueHostnames {
+			uniqueHostnameMap[labels["hostname"]] = struct{}{}
+		} else {
+			// Use hard-coded hostname so wildcard domains don't make cardinality explode.
+			labels["hostname"] = "max-hostnames-reached"
 		}
-	}
-	if len(uniqueHostnameMap) > maxUniqueHostnames {
-		// Use hard-coded hostname so wildcard domains don't make cardinality explode.
-		labels["hostname"] = "max-hostnames-reached"
 	}
 
 	bytes := getBytes(logline)
@@ -129,16 +120,6 @@ func InitMetrics(additionalLabels ...string) *prometheus.Registry {
 		if err == nil {
 			maxUniqueHostnames = maxUniqueHostnamesInt
 			log.Printf("[DEBUG] Using %d for maxUniqueHostnames\n", maxUniqueHostnames)
-		}
-	}
-
-	hostnameCompactSecondsStr := os.Getenv("MODULE_METRICS_HOSTNAME_COMPACT_SECONDS")
-	if hostnameCompactSecondsStr != "" {
-		hostnameCompactSecondsInt, err := strconv.Atoi(maxUniqueHostnamesStr)
-		if err == nil {
-			hostnameCompactInterval = time.Second * time.Duration(hostnameCompactSecondsInt)
-			nextCompactTime = time.Now().Add(hostnameCompactInterval)
-			log.Printf("[DEBUG] Using %d seconds for hostnameCompactInterval\n", hostnameCompactSecondsInt)
 		}
 	}
 


### PR DESCRIPTION
Hostname compaction was broken for two reasons:
1. The `prometheus` package has its own internal cache of metric series that continue to be exported even if we stop incrementing the counter with a given `hostname` label so we still exceed our desired metric count.
1. Between compactions, if the total unique hostnames observed exceeded the maximum, every hostname would be counted in the `max-hostnames-reached` bucket even if it was a previously accepted hostname.

Instead we'll record metrics for the first N hostnames always and all hostnames that appear later will never be counted even if they become the dominant hostname in requests.

If we find that hostname distribution shifts significantly more often than Pods roll then we can revisit a different design.

Also reduce the default value for max hostnames because 20,000 is crazy large when combined with status label combinations.