### PR TITLE
Providing GeoIP hash precision parameter.

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -235,9 +235,9 @@ func StartReader(file io.ReadCloser, output io.Writer, errorWriter io.Writer) {
 // metric label of 'geo_hash' after converting the lat/lon to a GeoIP
 // hash
 func SetupWithGeoHash(
-	precision uint,
 	path string,
 	stdout io.Writer, stderr io.Writer,
+	precision uint,
 	additionalLabels ...string) error {
 
 	isGeoHashing = true

--- a/p8s.go
+++ b/p8s.go
@@ -45,8 +45,13 @@ var (
 	maxUniqueHostnames = 1000
 )
 
+// Logf is a type that can be provided for outputing logs to specifi stream
 type Logf func(format string, v ...interface{})
 
+// ShowLabels outputs via the log function the "effective" labels
+// which can optionally include "geo_hash".  The intent is to
+// reconcile the labels used for initialization vs the ones output
+// when extracting metrics during some kind of issue
 func ShowLabels(log Logf) {
 	log("[INFO] logFieldNames %+v", logFieldNames)
 	log("[INFO] sanitizedP8sLabels %+v", sanitizedP8sLabels)

--- a/p8s_test.go
+++ b/p8s_test.go
@@ -309,7 +309,6 @@ func TestReaderRunning(t *testing.T) {
 }
 
 func TestSetupModule(t *testing.T) {
-	t.Skip("doesn't work")
 	if testing.Short() {
 		t.Skip("Skipping test in short mode.")
 	}
@@ -337,7 +336,7 @@ func TestSetupModule(t *testing.T) {
 
 	actual := gatherP8sResponse(t)
 
-	assert.Contains(t, actual, `section_http_request_count_total{content_type_bucket="javascript",hostname="www.example.com",status="200"} 1`)
+	assert.Contains(t, actual, `section_http_request_count_total{content_type_bucket="javascript",hostname="www.example.com",status="200"} 2`)
 	assert.Contains(t, actual, `section_http_bytes_total{content_type_bucket="html",hostname="www.example.com",status="304"} 1790`)
 }
 

--- a/reduce_geo.go
+++ b/reduce_geo.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -61,9 +60,7 @@ func convertLatLon(rawLat, rawLon string) (float64, float64, error) {
 	lat, latErr := strconv.ParseFloat(rawLat, 64)
 	lon, lonErr := strconv.ParseFloat(rawLon, 64)
 	if latErr != nil || lonErr != nil {
-		err := errors.New(
-			fmt.Sprintf("%+v and %+v", latErr, lonErr),
-		)
+		err := fmt.Errorf("%+v and %+v", latErr, lonErr)
 		return lat, lon, err
 	}
 	return lat, lon, nil
@@ -118,7 +115,7 @@ func convertLatLonToHash(labels map[string]string, logline map[string]interface{
 		labels[geoHash] = geoMissing
 		return labels, c
 	}
-	hash := geohash.EncodeWithPrecision(c.lat, c.lon, geoHashPrecision)
+	hash := geohash.EncodeWithPrecision(c.lat, c.lon, effectiveHashPrecision)
 	labels[geoHash] = hash
 	return labels, c
 }


### PR DESCRIPTION
Providing GeoIP hash precision parameter.  Cleaned up code based on lint output.  Fixed a skipped test.

Will need to make a release from these changes to then incorporate the resulting reference in dependent go.mod files.