### PR TITLE
Improve handling of AEE health checks 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/prometheus/client_golang v1.13.0
 	github.com/prometheus/common v0.37.0
 	github.com/stretchr/testify v1.8.0
+	github.com/thedevsaddam/gojsonq/v2 v2.5.2
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 )
 

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/thedevsaddam/gojsonq/v2 v2.5.2 h1:CoMVaYyKFsVj6TjU6APqAhAvC07hTI6IQen8PHzHYY0=
+github.com/thedevsaddam/gojsonq/v2 v2.5.2/go.mod h1:bv6Xa7kWy82uT0LnXPE2SzGqTj33TAEeR560MdJkiXs=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/metrics.go
+++ b/metrics.go
@@ -203,6 +203,8 @@ func StartReader(file io.ReadCloser, output io.Writer, errorWriter io.Writer) {
 						})
 					}
 				}
+				isAeeHealthcheck := aeeUserAgentRegex.MatchString(extractUserAgent(logline))
+				labelValues[aeeHealthcheckLabel] = strconv.FormatBool(isAeeHealthcheck)
 				addRequest(labelValues, logline)
 			}
 

--- a/p8s.go
+++ b/p8s.go
@@ -7,11 +7,13 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	gojsonq "github.com/thedevsaddam/gojsonq/v2"
 	"golang.org/x/exp/slices"
 )
 
@@ -50,6 +52,8 @@ var (
 	maxUniqueHostnames = 1000
 
 	includeHostnameMetrics = false
+
+	aeeUserAgentRegex = regexp.MustCompile(`^aee/v.+`)
 )
 
 // Logf is a type that can be provided for outputing logs to specifi stream
@@ -66,10 +70,21 @@ func ShowLabels(log Logf) {
 	log("[INFO] requestLabels %+v", requestLabels)
 }
 
+func extractUserAgent(logline map[string]interface{}) string {
+	userAgent := gojsonq.New().FromInterface(logline).Find("request.http_user_agent")
+	if userAgent != nil {
+		if userAgentStr, ok := userAgent.(string); ok {
+			return userAgentStr
+		}
+	}
+	return ""
+}
+
 func isPageView(logline map[string]interface{}) bool {
 	// Count text/html 2XX requests as page-views
 	return strings.HasPrefix(fmt.Sprintf("%v", logline["status"]), "2") &&
-		strings.HasPrefix(strings.ToLower(fmt.Sprintf("%v", logline["content_type"])), "text/html")
+		strings.HasPrefix(strings.ToLower(fmt.Sprintf("%v", logline["content_type"])), "text/html") &&
+		!aeeUserAgentRegex.MatchString(extractUserAgent(logline))
 }
 
 func addRequest(labels map[string]string, logline map[string]interface{}) {

--- a/p8s.go
+++ b/p8s.go
@@ -24,6 +24,8 @@ const (
 	promeSubsystem     = "http"
 	promeNamespace     = "section"
 	hostnameLabel      = "hostname"
+
+	aeeHealthcheckLabel = "section_aee_healthcheck"
 )
 
 var (
@@ -144,6 +146,7 @@ func InitMetrics(additionalLabels ...string) *prometheus.Registry {
 	}
 
 	requestLabels = sanitizedP8sLabels
+	requestLabels = append(requestLabels, aeeHealthcheckLabel)
 	if isGeoHashing {
 		requestLabels = append(requestLabels, geoHash)
 	}

--- a/p8s_test.go
+++ b/p8s_test.go
@@ -99,7 +99,7 @@ func testCountersIncreaseWithoutHostnameLabel(t *testing.T, stdout *bytes.Buffer
 
 	actual := gatherP8sResponse(t)
 
-	assert.Contains(t, actual, `section_http_request_count_total 10`)
+	assert.Contains(t, actual, `section_http_request_count_total{section_aee_healthcheck="false"} 10`)
 	assert.Contains(t, actual, `section_http_bytes_total 6949`)
 
 	assert.NotContains(t, actual, `section_http_request_count_by_hostname_total`)
@@ -127,7 +127,7 @@ func testCountersIncrease(t *testing.T, stdout *bytes.Buffer) {
 
 	actual := gatherP8sResponse(t)
 
-	assert.Contains(t, actual, `section_http_request_count_total 10`)
+	assert.Contains(t, actual, `section_http_request_count_total{section_aee_healthcheck="false"} 10`)
 	assert.Contains(t, actual, `section_http_bytes_total 6949`)
 
 	assert.Contains(t, actual, `section_http_request_count_by_hostname_total{hostname="www.example.com"} 7`)
@@ -147,7 +147,7 @@ func testBytesAndBytesSentAreRead(t *testing.T, stdout *bytes.Buffer) {
 
 	actual := gatherP8sResponse(t)
 
-	assert.Contains(t, actual, `section_http_request_count_total 2`)
+	assert.Contains(t, actual, `section_http_request_count_total{section_aee_healthcheck="false"} 2`)
 	assert.Contains(t, actual, `section_http_bytes_total 30`)
 
 	assert.Contains(t, actual, `section_http_request_count_by_hostname_total{hostname="www.example.com"} 2`)
@@ -169,7 +169,7 @@ func testInvalidBytesAndBytesSent(t *testing.T, stdout *bytes.Buffer) {
 
 	actual := gatherP8sResponse(t)
 
-	assert.Contains(t, actual, `section_http_request_count_total 4`)
+	assert.Contains(t, actual, `section_http_request_count_total{section_aee_healthcheck="false"} 4`)
 	assert.Contains(t, actual, `section_http_bytes_total 30`)
 
 	assert.Contains(t, actual, `section_http_request_count_by_hostname_total{hostname="www.example.com"} 4`)
@@ -214,7 +214,7 @@ func testP8sServer(t *testing.T, stdout *bytes.Buffer) {
 
 	actual := getP8sHTTPResponse(t)
 
-	assert.Contains(t, actual, `section_http_request_count_total 10`)
+	assert.Contains(t, actual, `section_http_request_count_total{section_aee_healthcheck="false"} 10`)
 	assert.Contains(t, actual, `section_http_bytes_total 6949`)
 
 	assert.Contains(t, actual, `section_http_request_count_by_hostname_total{hostname="www.example.com"} 7`)
@@ -234,7 +234,7 @@ func testAdditionalLabelsAreUsed(t *testing.T, stdout *bytes.Buffer) {
 
 	actual := gatherP8sResponse(t)
 
-	assert.Contains(t, actual, `section_http_request_count_total{http_accept_encoding="gzip"} 2`)
+	assert.Contains(t, actual, `section_http_request_count_total{http_accept_encoding="gzip",section_aee_healthcheck="false"} 2`)
 	assert.Contains(t, actual, `section_http_bytes_total{http_accept_encoding="gzip"} 30`)
 
 	assert.Contains(t, actual, `section_http_request_count_by_hostname_total{hostname="www.example.com"} 2`)
@@ -254,7 +254,7 @@ func testAdditionalLabelsWhenMissingFromLogs(t *testing.T, stdout *bytes.Buffer)
 
 	actual := gatherP8sResponse(t)
 
-	assert.Contains(t, actual, `section_http_request_count_total{missing_field=""} 2`)
+	assert.Contains(t, actual, `section_http_request_count_total{missing_field="",section_aee_healthcheck="false"} 2`)
 	assert.Contains(t, actual, `section_http_bytes_total{missing_field=""} 30`)
 
 	assert.Contains(t, actual, `section_http_request_count_by_hostname_total{hostname="www.example.com"} 2`)
@@ -273,8 +273,8 @@ func testNonStringProperties(t *testing.T, stdout *bytes.Buffer) {
 
 	actual := gatherP8sResponse(t)
 
-	assert.Contains(t, actual, `section_http_request_count_total{bool="",int="12345"} 1`)
-	assert.Contains(t, actual, `section_http_request_count_total{bool="true",int=""} 1`)
+	assert.Contains(t, actual, `section_http_request_count_total{bool="",int="12345",section_aee_healthcheck="false"} 1`)
+	assert.Contains(t, actual, `section_http_request_count_total{bool="true",int="",section_aee_healthcheck="false"} 1`)
 
 	assert.Contains(t, actual, `section_http_request_count_by_hostname_total{hostname="www.example.com"} 2`)
 }
@@ -333,8 +333,8 @@ func testContentTypeBucket(t *testing.T, stdout *bytes.Buffer) {
 
 	actual := gatherP8sResponse(t)
 
-	assert.Contains(t, actual, `section_http_request_count_total{content_type_bucket="html"} 3`)
-	assert.Contains(t, actual, `section_http_request_count_total{content_type_bucket=""} 1`)
+	assert.Contains(t, actual, `section_http_request_count_total{content_type_bucket="html",section_aee_healthcheck="false"} 3`)
+	assert.Contains(t, actual, `section_http_request_count_total{content_type_bucket="",section_aee_healthcheck="false"} 1`)
 
 	assert.Contains(t, actual, `section_http_request_count_by_hostname_total{hostname="www.example.com"} 4`)
 }
@@ -433,7 +433,9 @@ func TestAddRequestUniqueHostnames(t *testing.T) {
 		"content_type": "text/plain",
 		"status":       "405",
 	}
-	labels := map[string]string{}
+	labels := map[string]string{
+		aeeHealthcheckLabel: "false",
+	}
 
 	// first unique hostname
 	labels["hostname"] = "a.foo.com"

--- a/reduce_geo.go
+++ b/reduce_geo.go
@@ -129,6 +129,8 @@ func scrubGeoHash(labels map[string]string) map[string]string {
 		switch k {
 		case geoHash: // remove/scrub these keys
 			continue
+		case aeeHealthcheckLabel:
+			continue
 		default:
 			rv[k] = v
 		}


### PR DESCRIPTION
These changes are the module-metrics pieces of [TP 21968](https://section.tpondemand.com/entity/21968-update-module-metrics) and [TP 21973](https://section.tpondemand.com/entity/21973-update-module-metrics), which include excluding AEE health checks from page views, and adding a new label for total requests that allows AEE health checks to be split out from non-AEE health check requests. Best viewed by commit.